### PR TITLE
Fix for Issue: Do not allow a member to register for challenge if country is not set (master)

### DIFF
--- a/initializers/challengeHelper.js
+++ b/initializers/challengeHelper.js
@@ -161,6 +161,12 @@ exports.challengeHelper = function (api, next) {
                         return;
                     }
 
+                    // Do not allow a member to register for challenge if country is not set
+                    if (rows[0].comp_country_is_null) {
+                        cb(new ForbiddenError('You cannot participate in this challenge as your country is not set.'));
+                        return;
+                    }
+
                     if (rows[0].project_category_id === COPILOT_POSTING_PROJECT_TYPE) {
                         if (!rows[0].user_is_copilot && rows[0].copilot_type && rows[0].copilot_type.indexOf("Marathon Match") < 0) {
                             cb(new ForbiddenError('You cannot participate in this challenge because you are not an active member of the copilot pool.'));

--- a/queries/challenge_registration_validations
+++ b/queries/challenge_registration_validations
@@ -7,6 +7,7 @@ select
 	(ce.contest_eligibility_id IS NULL) as no_elgibility_req,
 	(ugx.login_id IS NOT NULL) as user_in_eligible_group,
  	(uax.user_id IS NOT NULL OR coder.coder_id IS NOT NULL) as user_country_banned,
+	(coder2.comp_country_code IS NULL) as comp_country_is_null,
 	(cop.copilot_profile_id IS NOT NULL) as user_is_copilot,
 	(pctl.name) as copilot_type
 from project p
@@ -50,6 +51,8 @@ left outer join (
 	on coder.comp_country_code=country.country_code
 	and country.country_name in ( "Iran", "North Korea", "Cuba", "Sudan", "Syria" )
 ) on coder.coder_id = @userId@
+-- Get coder to check comp_country_code
+left outer join informixoltp:coder coder2 on coder2.coder_id = @userId@
 -- Get the copilot type
 left join (
 	project_copilot_type pct join project_copilot_type_lu pctl


### PR DESCRIPTION
Fix for the issue: Do not allow a member to register for challenge if country is not set
https://app.asana.com/0/152805928309317/156182574694106

- Add a check for coder.comp_country_code in the challenge registration validation.