### PR TITLE
Fix for the issue: Do not allow a member to register for challenge if country is not set

### DIFF
--- a/initializers/challengeHelper.js
+++ b/initializers/challengeHelper.js
@@ -157,13 +157,13 @@ exports.challengeHelper = function (api, next) {
                     }
 
                     if (rows[0].user_country_banned) {
-                        cb(new ForbiddenError('You cannot participate in this challenge as your country is banned.'));
+                        cb(new ForbiddenError('You are not eligible to participate in this challenge because of your country of residence. Please see our terms of service for more information.'));
                         return;
                     }
 
                     // Do not allow a member to register for challenge if country is not set
                     if (rows[0].comp_country_is_null) {
-                        cb(new ForbiddenError('You cannot participate in this challenge as your country is not set.'));
+                        cb(new ForbiddenError('You are not eligible to participate in this challenge because you have not specified your country of residence. Please go to your Settings and enter a country. Please see our terms of service for more information.'));
                         return;
                     }
 

--- a/queries/challenge_registration_validations
+++ b/queries/challenge_registration_validations
@@ -7,7 +7,7 @@ select
 	(ce.contest_eligibility_id IS NULL) as no_elgibility_req,
 	(ugx.login_id IS NOT NULL) as user_in_eligible_group,
  	(uax.user_id IS NOT NULL OR coder.coder_id IS NOT NULL) as user_country_banned,
-	(coder2.comp_country_code IS NULL) as comp_country_is_null,
+	(coder2.comp_country_code IS NULL OR coder2.comp_country_code = '') as comp_country_is_null,
 	(cop.copilot_profile_id IS NOT NULL) as user_is_copilot,
 	(pctl.name) as copilot_type
 from project p


### PR DESCRIPTION
Do not allow a member to register for challenge if country is not set
(https://app.asana.com/0/152805928309317/156182574694106)
- Added check for the case that the competition country is empty
- Modified error messages