### PR TITLE
Fix for the issue: Do not allow a member to register for challenge if country is not set#3

### DIFF
--- a/queries/challenge_registration_validations
+++ b/queries/challenge_registration_validations
@@ -48,8 +48,10 @@ left outer join (
 -- Check coder's country
 left outer join (
 	informixoltp:coder coder join informixoltp:country country
-	on coder.comp_country_code=country.country_code
-	and country.country_name in ( "Iran", "North Korea", "Cuba", "Sudan", "Syria" )
+	on (
+        coder.comp_country_code=country.country_code OR
+        coder.home_country_code=country.country_code
+  ) and country.country_name in ( "Iran", "North Korea", "Cuba", "Sudan", "Syria" )
 ) on coder.coder_id = @userId@
 -- Get coder to check comp_country_code
 left outer join informixoltp:coder coder2 on coder2.coder_id = @userId@


### PR DESCRIPTION
Do not allow a member to register for challenge if country is not set
(https://app.asana.com/0/152805928309317/156182574694106)
- Checking coder.home_country_code