### PR TITLE
remove inefficient join

### DIFF
--- a/queries/challenge_terms_of_use_noauth
+++ b/queries/challenge_terms_of_use_noauth
@@ -6,7 +6,7 @@ SELECT 	tou.terms_of_use_id as terms_of_use_id,
 FROM project_role_terms_of_use_xref
 INNER JOIN terms_of_use tou ON project_role_terms_of_use_xref.terms_of_use_id = tou.terms_of_use_id
 INNER JOIN terms_of_use_agreeability_type_lu touat ON touat.terms_of_use_agreeability_type_id = tou.terms_of_use_agreeability_type_id
-LEFT JOIN user_terms_of_use_xref utuox ON utuox.terms_of_use_id = tou.terms_of_use_id
+--LEFT JOIN user_terms_of_use_xref utuox ON utuox.terms_of_use_id = tou.terms_of_use_id
 LEFT JOIN terms_of_use_docusign_template_xref dtx ON dtx.terms_of_use_id = project_role_terms_of_use_xref.terms_of_use_id
 WHERE project_id = @challengeId@ AND 
 resource_role_id IN (@resourceRoleIds@)


### PR DESCRIPTION
This query was pulling in a redundant row for every user that agrees to the give terms_id.  WIth 30k plus rows, this was really inefficient and locking up resources.